### PR TITLE
feat: add list command alias for ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Commands:
   undep <id> <dep-id>      Remove dependency
   link <id> <id> [id...]   Link tickets together (symmetric)
   unlink <id> <target-id>  Remove link between tickets
-  ls [--status=X]          List tickets
+  ls|list [--status=X]     List tickets
   ready                    List open/in-progress tickets with deps resolved
   blocked                  List open/in-progress tickets with unresolved deps
   closed [--limit=N]       List recently closed tickets (default 20, by mtime)

--- a/ticket
+++ b/ticket
@@ -1208,7 +1208,7 @@ Commands:
   undep <id> <dep-id>      Remove dependency
   link <id> <id> [id...]   Link tickets together (symmetric)
   unlink <id> <target-id>  Remove link between tickets
-  ls [--status=X]          List tickets
+  ls|list [--status=X]     List tickets
   ready                    List open/in-progress tickets with deps resolved
   blocked                  List open/in-progress tickets with unresolved deps
   closed [--limit=N]       List recently closed tickets (default 20, by mtime)
@@ -1234,7 +1234,7 @@ case "${1:-help}" in
     undep)  shift; cmd_undep "$@" ;;
     link)   shift; cmd_link "$@" ;;
     unlink) shift; cmd_unlink "$@" ;;
-    ls)     shift; cmd_ls "$@" ;;
+    ls|list) shift; cmd_ls "$@" ;;
     ready)  cmd_ready ;;
     blocked) cmd_blocked ;;
     closed) shift; cmd_closed "$@" ;;


### PR DESCRIPTION
## Summary
- Add `list` as an alias for the `ls` command
- Update help text to show `ls|list [--status=X]`
- Update README documentation to reflect the alias

## Details
Users can now use either `tk ls` or `tk list` to list tickets, providing a more intuitive command name.