### PR TITLE
feat: support setting custom tickets directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Support `TICKETS_DIR` environment variable for custom tickets directory location
 - `dep cycle` command to detect dependency cycles in open tickets
 - `add-note` command for appending timestamped notes to tickets
 - `-a, --assignee` filter flag for `ls`, `ready`, `blocked`, and `closed` commands

--- a/ticket
+++ b/ticket
@@ -4,7 +4,7 @@ set -euo pipefail
 # ticket - minimal ticket system with dependency tracking
 # Stores markdown files with YAML frontmatter in .tickets/
 
-TICKETS_DIR=".tickets"
+TICKETS_DIR="${TICKETS_DIR:-.tickets}"
 
 # Prefer ripgrep if available, fall back to grep
 if command -v rg &>/dev/null; then


### PR DESCRIPTION
A small change to support setting a custom `TICKETS_DIR`, so that tk can be used as a global task tracker across multiple repositories.