### PR TITLE
bug: allow partial IDs for all commands with ID args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `undep` command now resolves partial IDs and validates dependency exists
 - `unlink` command now resolves partial IDs for both arguments
 - `create --parent` now validates and resolves parent ticket ID
+- `generate_id` now uses 3-char prefix for single-segment directory names (e.g., "plan" → "pla" instead of "p")
 
 ## [0.3.0] - 2026-01-18
 

--- a/ticket
+++ b/ticket
@@ -42,8 +42,8 @@ generate_id() {
     local prefix
     prefix=$(echo "$dir_name" | sed 's/[-_]/ /g' | awk '{for(i=1;i<=NF;i++) printf substr($i,1,1)}')
 
-    # Fallback to first 3 chars if no segments
-    [[ -z "$prefix" ]] && prefix="${dir_name:0:3}"
+    # Fallback to first 3 chars if single segment (prefix too short)
+    [[ ${#prefix} -lt 2 ]] && prefix="${dir_name:0:3}"
 
     # 4-char hash from timestamp + PID for entropy
     local hash


### PR DESCRIPTION
some of the commands that accepts IDs were allowing partial IDs and others were not. this fixes the few that were not.