### PR TITLE
bug: fix prefix with only one segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - `--tags` flag for `create` command to add comma-separated tags
 - `-T, --tag` filter flag for `ls`, `ready`, `blocked`, and `closed` commands
 
+### Fixed
+- `generate_id` now uses 3-char prefix for single-segment directory names (e.g., "plan" → "pla" instead of "p")
+
 ## [0.2.0] - 2026-01-04
 
 ### Added

--- a/ticket
+++ b/ticket
@@ -42,8 +42,8 @@ generate_id() {
     local prefix
     prefix=$(echo "$dir_name" | sed 's/[-_]/ /g' | awk '{for(i=1;i<=NF;i++) printf substr($i,1,1)}')
 
-    # Fallback to first 3 chars if no segments
-    [[ -z "$prefix" ]] && prefix="${dir_name:0:3}"
+    # Fallback to first 3 chars if single segment (prefix too short)
+    [[ ${#prefix} -lt 2 ]] && prefix="${dir_name:0:3}"
 
     # 4-char hash from timestamp + PID for entropy
     local hash


### PR DESCRIPTION
if the directory was only one segment (no - or _) it was just using the first character of the dir_name even though the code after mentioned using the first three characters if no segments