### PR TITLE
feat: Add TICKET_PAGER support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - `list` command alias for `ls`
+- `TICKET_PAGER` environment variable for `show` command (only when stdout is a TTY; falls back to `PAGER`)
 
 ### Changed
 - Walk parent directories to find `.tickets/` directory, enabling commands from any subdirectory

--- a/ticket
+++ b/ticket
@@ -55,6 +55,8 @@ init_tickets_dir() {
     return 1
 }
 
+TICKET_PAGER="${TICKET_PAGER:-${PAGER:-}}"
+
 # Prefer ripgrep if available, fall back to grep
 if command -v rg &>/dev/null; then
     _grep() { rg "$@"; }
@@ -1130,7 +1132,8 @@ cmd_show() {
     local target_id
     target_id=$(basename "$file" .md)
 
-    awk -v target="$target_id" -v target_file="$file" '
+    _show_output() {
+        awk -v target="$target_id" -v target_file="$file" '
     BEGIN { FS=": "; in_front=0 }
 
     # First pass: collect all ticket metadata
@@ -1262,6 +1265,14 @@ cmd_show() {
         }
     }
     ' "$TICKETS_DIR"/*.md 2>/dev/null
+    }
+
+    if [[ -t 1 && -n "$TICKET_PAGER" ]]; then
+        read -r -a pager_cmd <<<"$TICKET_PAGER"
+        _show_output | "${pager_cmd[@]}"
+    else
+        _show_output
+    fi
 }
 
 cmd_add_note() {


### PR DESCRIPTION
Adds pager support for `tk show` output. Uses `TICKET_PAGER` env var, falls back to `PAGER`. For example with [glow](https://github.com/charmbracelet/glow): 

<img width="571" height="203" alt="image" src="https://github.com/user-attachments/assets/4f47ee4f-6419-44b3-aa1a-6fbb6c4063d1" />


