### PR TITLE
feat: Use full a-z 0-9 for id creation

### DIFF
--- a/features/steps/ticket_steps.py
+++ b/features/steps/ticket_steps.py
@@ -368,7 +368,7 @@ def step_output_not_contains(context, text):
 def step_output_matches_id_pattern(context):
     """Assert output matches ticket ID pattern (prefix-hash)."""
     # Prefix can be alphanumeric (from directory name), hash is 4 hex chars
-    pattern = r'^[a-z0-9]+-[a-f0-9]{4}$'
+    pattern = r'^[a-z0-9]+-[a-z0-9]{4}$'
     assert re.match(pattern, context.stdout), \
         f"Output '{context.stdout}' does not match ticket ID pattern"
 

--- a/ticket
+++ b/ticket
@@ -62,13 +62,6 @@ else
     _grep() { grep "$@"; }
 fi
 
-# Portable sha256 (Linux: sha256sum, macOS: shasum -a 256)
-if command -v sha256sum &>/dev/null; then
-    _sha256() { sha256sum; }
-else
-    _sha256() { shasum -a 256; }
-fi
-
 # Portable ISO date (GNU date supports -Iseconds, BSD date does not)
 _iso_date() {
     date -u +%Y-%m-%dT%H:%M:%SZ
@@ -82,7 +75,7 @@ _sed_i() {
     sed "$@" "$file" > "$tmp" && mv "$tmp" "$file"
 }
 
-# Generate ticket ID from directory name + timestamp hash
+# Generate ticket ID from directory name + random string
 generate_id() {
     local dir_name
     dir_name=$(basename "$(pwd)")
@@ -94,9 +87,9 @@ generate_id() {
     # Fallback to first 3 chars if single segment (prefix too short)
     [[ ${#prefix} -lt 2 ]] && prefix="${dir_name:0:3}"
 
-    # 4-char hash from timestamp + PID for entropy
+    # 4-char random lower case alphanumeric string
     local hash
-    hash=$(echo "$$$(date +%s)" | _sha256 | head -c 4)
+    hash=$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c 4)
 
     echo "${prefix}-${hash}"
 }


### PR DESCRIPTION
This relies on `tr` and `/dev/urandom`. Unclear if this works well on Mac, but on Linux it works just fine. `tr` is in coreutils.