### PR TITLE
don't default TICKET_PAGER="" to PAGER

### DIFF
--- a/features/steps/ticket_steps.py
+++ b/features/steps/ticket_steps.py
@@ -256,9 +256,9 @@ def step_run_command_no_stdin(context, command):
     context.returncode = result.returncode
 
 
-@when(r'I run "(?P<command>(?:[^"\\]|\\.)+)" with TICKETS_DIR set to "(?P<tickets_dir>[^"]+)"')
-def step_run_command_with_env(context, command, tickets_dir):
-    """Run a ticket CLI command with custom TICKETS_DIR."""
+@when(r'I run "(?P<command>(?:[^"\\]|\\.)+)" with (?P<var_name>[A-Z_]+) set to "(?P<var_value>[^"]*)"')
+def step_run_command_with_env(context, command, var_name, var_value):
+    """Run a ticket CLI command with a custom environment variable."""
     command = command.replace('\\"', '"')
     ticket_script = get_ticket_script(context)
     cmd = command.replace('ticket ', f'{ticket_script} ', 1)
@@ -266,9 +266,12 @@ def step_run_command_with_env(context, command, tickets_dir):
     # Use working_dir if set (from subdirectory step), otherwise test_dir
     cwd = getattr(context, 'working_dir', context.test_dir)
 
-    # Resolve tickets_dir relative to test_dir
     env = os.environ.copy()
-    env['TICKETS_DIR'] = str(Path(context.test_dir) / tickets_dir)
+    # Resolve TICKETS_DIR relative to test_dir
+    if var_name == 'TICKETS_DIR':
+        env[var_name] = str(Path(context.test_dir) / var_value)
+    else:
+        env[var_name] = var_value
 
     result = subprocess.run(
         cmd,

--- a/features/ticket_show.feature
+++ b/features/ticket_show.feature
@@ -75,6 +75,12 @@ Feature: Ticket Show
     And the output should contain "parent: show-001"
     And the output should contain "# Parent ticket"
 
+  Scenario: Show does not use pager when TICKET_PAGER is empty
+    Given a ticket exists with ID "show-001" and title "Test ticket"
+    When I run "ticket show show-001" with TICKET_PAGER set to ""
+    Then the command should succeed
+    And the output should contain "# Test ticket"
+
   Scenario: Show non-existent ticket
     When I run "ticket show nonexistent"
     Then the command should fail

--- a/ticket
+++ b/ticket
@@ -55,7 +55,7 @@ init_tickets_dir() {
     return 1
 }
 
-TICKET_PAGER="${TICKET_PAGER:-${PAGER:-}}"
+TICKET_PAGER="${TICKET_PAGER-${PAGER:-}}"
 
 # Prefer ripgrep if available, fall back to grep
 if command -v rg &>/dev/null; then


### PR DESCRIPTION
fixes a bug where TICKET_PAGER was being set to PAGER even if TICKET_PAGER was purposely set to "". unset will still default to PAGER