### PR TITLE
fix: handle quoted tags in YAML for query command

### DIFF
--- a/features/ticket_query.feature
+++ b/features/ticket_query.feature
@@ -46,3 +46,13 @@ Feature: Ticket Query
     When I run "ticket query"
     Then the command should succeed
     And the JSONL deps field should be a JSON array
+
+  Scenario: Query handles quoted tags in YAML
+    Given a ticket exists with ID "query-001" and title "Tagged ticket"
+    And ticket "query-001" has tags ["simplification-opportunity", "refactor"]
+    When I run "ticket query"
+    Then the command should succeed
+    And the output should be valid JSONL
+    And the JSONL tags field should be a JSON array
+    And the JSONL tags field should contain "simplification-opportunity"
+    And the JSONL tags field should contain "refactor"

--- a/ticket
+++ b/ticket
@@ -1352,6 +1352,8 @@ cmd_query() {
                     for (j = 1; j <= n; j++) {
                         if (j > 1) printf ","
                         gsub(/^ +| +$/, "", items[j])
+                        # Strip quotes from items (handles both single and double quotes)
+                        gsub(/^["\047]|["\047]$/, "", items[j])
                         if (items[j] != "") printf "\"%s\"", items[j]
                     }
                     printf "]"


### PR DESCRIPTION
The query command was double-quoting tag values when YAML used quoted array syntax (e.g., tags: ["tag1", "tag2"]), producing invalid JSON like {"tags":[[""tag""]]}.

Strip quotes from array items in awk before re-quoting for JSON output. Add tests to verify quoted YAML tags produce valid JSON arrays.