### PR TITLE
bug: .tickets not working correctly when symlinked

### DIFF
--- a/features/id_resolution.feature
+++ b/features/id_resolution.feature
@@ -69,3 +69,10 @@ Feature: Ticket ID Resolution
     When I run "ticket link cccc dddd"
     Then the command should succeed
     And ticket "link-cccc" should have "link-dddd" in links
+
+  Scenario: Partial ID match works with symlinked tickets directory
+    Given a symlinked tickets directory
+    And a ticket exists with ID "sym-1234" and title "Symlink test"
+    When I run "ticket show 1234"
+    Then the command should succeed
+    And the output should contain "id: sym-1234"

--- a/features/steps/ticket_steps.py
+++ b/features/steps/ticket_steps.py
@@ -207,6 +207,26 @@ Description
     ticket_path.write_text(content)
 
 
+@given(r'a symlinked tickets directory')
+def step_symlinked_tickets_directory(context):
+    """Create .tickets as a symlink to a real directory elsewhere."""
+    import shutil
+
+    # Create the actual tickets directory in a subdirectory
+    real_dir = Path(context.test_dir) / 'real_tickets_dir' / '.tickets'
+    real_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove existing .tickets (could be a directory or symlink)
+    symlink_path = Path(context.test_dir) / '.tickets'
+    if symlink_path.is_symlink():
+        symlink_path.unlink()
+    elif symlink_path.exists():
+        shutil.rmtree(symlink_path)
+
+    # Create symlink at .tickets pointing to the real directory
+    symlink_path.symlink_to(real_dir)
+
+
 # ============================================================================
 # When Steps
 # ============================================================================

--- a/ticket
+++ b/ticket
@@ -113,7 +113,7 @@ ticket_path() {
 
     # Try partial match (anywhere in filename)
     local matches
-    matches=$(find "$TICKETS_DIR" -maxdepth 1 -name "*${id}*.md" 2>/dev/null | head -2)
+    matches=$(find -L "$TICKETS_DIR" -maxdepth 1 -name "*${id}*.md" 2>/dev/null | head -2)
     local count
     count=$(echo "$matches" | _grep -c . || true)
 


### PR DESCRIPTION
there was a bug that if your `.tickets` directory was a symlink then partial IDs did not work correctly because find was not scanning the symlinked directory correctly.