### PR TITLE
Enhancement to ticket create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Usage: tk <command> [args]
 Commands:
   create [title] [options] Create ticket, prints ID
     -d, --description      Description text, or - to read from stdin
+    -e, --edit             Open editor ($VISUAL or $EDITOR or vi) to edit ticket
     --design               Design notes
     --acceptance           Acceptance criteria
     -t, --type             Type (bug|feature|task|epic|chore) [default: task]

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Usage: tk <command> [args]
 
 Commands:
   create [title] [options] Create ticket, prints ID
-    -d, --description      Description text
+    -d, --description      Description text, or - to read from stdin
     --design               Design notes
     --acceptance           Acceptance criteria
     -t, --type             Type (bug|feature|task|epic|chore) [default: task]

--- a/ticket
+++ b/ticket
@@ -158,7 +158,7 @@ cmd_create() {
     ensure_dir
 
     local title="" description="" design="" acceptance=""
-    local priority=2 issue_type="task" assignee="" external_ref="" parent="" tags=""
+    local priority=2 issue_type="task" assignee="" external_ref="" parent="" tags="" edit=""
 
     # Default assignee to git user.name if available
     assignee=$(git config user.name 2>/dev/null || true)
@@ -175,6 +175,7 @@ cmd_create() {
             --external-ref) external_ref="$2"; shift 2 ;;
             --parent) parent="$2"; shift 2 ;;
             --tags) tags="$2"; shift 2 ;;
+            -e|--edit) edit=1; shift ;;
             -*) echo "Unknown option: $1" >&2; return 1 ;;
             *) title="$1"; shift ;;
         esac
@@ -233,6 +234,10 @@ cmd_create() {
             echo ""
         fi
     } > "$file"
+
+    if [[ $edit = 1 ]]; then
+      ${VISUAL:-${EDITOR:-vi}} "$file"
+    fi
 
     echo "$id"
 }

--- a/ticket
+++ b/ticket
@@ -180,6 +180,10 @@ cmd_create() {
         esac
     done
 
+    if [[ $description = "-" ]]; then
+        description="$(< /dev/stdin)"
+    fi
+
     # Validate and resolve parent if specified
     if [[ -n "$parent" ]]; then
         local parent_file
@@ -1300,7 +1304,7 @@ Usage: $cmd <command> [args]
 
 Commands:
   create [title] [options] Create ticket, prints ID
-    -d, --description      Description text
+    -d, --description      Description text (or "-" to read from stdin)
     --design               Design notes
     --acceptance           Acceptance criteria
     -t, --type             Type (bug|feature|task|epic|chore) [default: task]


### PR DESCRIPTION
This PR makes two changes to ticket create:

- Allow reading description from stdin by specifying `--description -` (or `-d -`)
- Allow opening ticket in an editor immediately by specifying `--edit` (or `-e`)

This includes updates to README.md.